### PR TITLE
fix(CP-45): Fix crash during HealthKit sync

### DIFF
--- a/packages/health/ios/Classes/SwiftHealthPlugin.swift
+++ b/packages/health/ios/Classes/SwiftHealthPlugin.swift
@@ -230,8 +230,6 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
         let startDate = (arguments?["startDate"] as? NSNumber) ?? 0
         let endDate = (arguments?["endDate"] as? NSNumber) ?? 0
         let healthStore = HKHealthStore()
-        
-        NSLog("dataUnitKey: \(dataUnitKey)")
 
         // Convert dates from milliseconds to Date()
         let dateFrom = Date(timeIntervalSince1970: startDate.doubleValue / 1000)
@@ -242,8 +240,6 @@ public class SwiftHealthPlugin: NSObject, FlutterPlugin {
         if let dataUnitKey = dataUnitKey {
             unit = unitDict[dataUnitKey]
         }
-        
-        NSLog("unit: \(unit)")
 
         let predicate = HKQuery.predicateForSamples(
             withStart: dateFrom, end: dateTo, options: .strictStartDate)

--- a/packages/health/lib/src/health_factory.dart
+++ b/packages/health/lib/src/health_factory.dart
@@ -107,13 +107,14 @@ class HealthFactory {
   /// The main function for fetching health data
   Future<List<HealthDataPoint>> _dataQuery(DateTime startDate, DateTime endDate, HealthDataType dataType) async {
     // Set parameters for method channel request
+    final unit = _dataTypeToUnit[dataType]!;
     final args = <String, dynamic>{
       'dataTypeKey': _enumToString(dataType),
+      'dataUnitKey': unit.name,
       'startDate': startDate.millisecondsSinceEpoch,
       'endDate': endDate.millisecondsSinceEpoch
     };
 
-    final unit = _dataTypeToUnit[dataType]!;
     final fetchedDataPoints = await _channel.invokeMethod('getData', args);
     if (fetchedDataPoints != null) {
       return fetchedDataPoints.map<HealthDataPoint>((e) {

--- a/packages/health/pubspec.yaml
+++ b/packages/health/pubspec.yaml
@@ -1,6 +1,6 @@
 name: health
 description: Wrapper for the iOS HealthKit and Android GoogleFit services.
-version: 4.0.1
+version: 4.0.2
 homepage: https://gitlab.com/petleo-and-iatros-opensource/health-advanced
 
 environment:


### PR DESCRIPTION
- Attempts to [fix this crash](https://avimedical.sentry.io/issues/8097470/events/bb428c5509c242ddafa741f51d993e78/events/?project=4507610748420176) during the sync on HealthKit.
   -  The stack trace suggest that a given key is not present in `unitDict` using in the `unitLookUp` method to return the unit of measurement
- The fix is based on [a fix](https://github.com/cph-cachet/flutter-plugins/pull/578) to a similar issue from the official plugin
- Aligns all data & unit types from the official plugin and our own.
- Passes unit type into HealthKit data request